### PR TITLE
Added STAU in the enum MotherNames class and added gentau vertex info (needed for displ. study)

### DIFF
--- a/Producer/plugins/NTupleMaker.cc
+++ b/Producer/plugins/NTupleMaker.cc
@@ -1059,6 +1059,10 @@ void NTupleMaker::beginJob(){
       tree->Branch("gentau_visible_phi", gentau_visible_phi, "tau_visible_phi[gentau_count]/F");
       tree->Branch("gentau_visible_mass", gentau_visible_mass, "tau_visible_mass[gentau_count]/F");
 
+      tree->Branch("gentau_vx", gentau_vx, "gentau_vx[gentau_count]/F");
+      tree->Branch("gentau_vy", gentau_vy, "gentau_vy[gentau_count]/F");
+      tree->Branch("gentau_vz", gentau_vz, "gentau_vz[gentau_count]/F");
+
       tree->Branch("gentau_visibleNoLep_e",  gentau_visibleNoLep_e,  "tau_visibleNoLep_e[gentau_count]/F");
       tree->Branch("gentau_visibleNoLep_pt",  gentau_visibleNoLep_pt,  "tau_visibleNoLep_pt[gentau_count]/F");
       tree->Branch("gentau_visibleNoLep_eta", gentau_visibleNoLep_eta, "tau_visibleNoLep_eta[gentau_count]/F");
@@ -3094,6 +3098,10 @@ bool NTupleMaker::AddGenParticles(const edm::Event& iEvent) {
 	      gentau_visible_py[gentau_count] = tau_visible_p4.py();
 	      gentau_visible_pz[gentau_count] = tau_visible_p4.pz();
 	      gentau_visible_e[gentau_count]  = tau_visible_p4.energy();
+
+	      gentau_vx[gentau_count] = (*GenParticles)[i].vx();
+	      gentau_vy[gentau_count] = (*GenParticles)[i].vy();
+	      gentau_vz[gentau_count] = (*GenParticles)[i].vz();
 
 	      gentau_visible_pt[gentau_count]   = tau_visible_p4.pt();
 	      gentau_visible_eta[gentau_count]  = tau_visible_p4.eta();

--- a/Producer/plugins/NTupleMaker.cc
+++ b/Producer/plugins/NTupleMaker.cc
@@ -3035,6 +3035,7 @@ bool NTupleMaker::AddGenParticles(const edm::Event& iEvent) {
 	      if(HasAnyMother(&(*GenParticles)[i], 15) > 0) {info |= 1<<2; mother=TAU;}
 	      if(HasAnyMother(&(*GenParticles)[i], 25) > 0 || HasAnyMother(&(*GenParticles)[i], 35) > 0 ||
 		 HasAnyMother(&(*GenParticles)[i], 36) > 0) {info |= 1<<3; mother=HIGGS;}
+        if(HasAnyMother(&(*GenParticles)[i], 1000015) > 0) {info |= 1<<4;mother=STAU;}
 	      //	      std::cout << "GenMuon : " << (*GenParticles)[i].pdgId()
 	      //			<< "   pt = " << (*GenParticles)[i].pt()
 	      //			<< "   eta = " << (*GenParticles)[i].eta()
@@ -3050,6 +3051,7 @@ bool NTupleMaker::AddGenParticles(const edm::Event& iEvent) {
 	      if(HasAnyMother(&(*GenParticles)[i], 15) > 0) {info |= 1<<2; mother=TAU;}
 	      if(HasAnyMother(&(*GenParticles)[i], 25) > 0 || HasAnyMother(&(*GenParticles)[i], 35) > 0 ||
                  HasAnyMother(&(*GenParticles)[i], 36) > 0) {info |= 1<<3; mother=HIGGS;}
+        if(HasAnyMother(&(*GenParticles)[i], 1000015) > 0) {info |= 1<<4;mother=STAU;}
 	      //	      std::cout << "GenElectron : " << (*GenParticles)[i].pdgId()
 	      //			<< "   pt = " << (*GenParticles)[i].pt()
 	      //			<< "   eta = " << (*GenParticles)[i].eta()
@@ -3065,6 +3067,7 @@ bool NTupleMaker::AddGenParticles(const edm::Event& iEvent) {
 	      if(HasAnyMother(&(*GenParticles)[i], 15) > 0) {info |= 1<<2; mother=TAU;}
 	      if(HasAnyMother(&(*GenParticles)[i], 25) > 0 || HasAnyMother(&(*GenParticles)[i], 35) > 0 ||
                  HasAnyMother(&(*GenParticles)[i], 36) > 0) {info |= 1<<3; mother=HIGGS;}
+        if(HasAnyMother(&(*GenParticles)[i], 1000015) > 0) {info |= 1<<4;mother=STAU;}
 	      //	      std::cout << "GenTau : "
 	      //	       		<< "   pt = " << (*GenParticles)[i].pt()
 	      //	       		<< "   eta = " << (*GenParticles)[i].eta()
@@ -3145,6 +3148,7 @@ bool NTupleMaker::AddGenParticles(const edm::Event& iEvent) {
 		if(HasAnyMother(&(*GenParticles)[i], 23) > 0 || HasAnyMother(&(*GenParticles)[i], 22) > 0) {info |= 1<<0;mother=ZBOSON;}
 		if(HasAnyMother(&(*GenParticles)[i], 24) > 0) {info |= 1<<1;mother=WBOSON;}
 		if(HasAnyMother(&(*GenParticles)[i], 15) > 0) {info |= 1<<2;mother=TAU;}
+    if(HasAnyMother(&(*GenParticles)[i], 1000015) > 0) {info |= 1<<4;mother=STAU;}
 		//		std::cout << "GenNeutrino : " << (*GenParticles)[i].pdgId()
 		//		 	  << "   pt = " << (*GenParticles)[i].pt()
 		//		 	  << "   eta = " << (*GenParticles)[i].eta()
@@ -3231,6 +3235,7 @@ bool NTupleMaker::AddGenParticles(const edm::Event& iEvent) {
 	    if(HasAnyMother(&(*GenParticles)[i], 25) > 0||
 	       HasAnyMother(&(*GenParticles)[i], 35) > 0||
 	       HasAnyMother(&(*GenParticles)[i], 36) > 0) {info |= 1<<3;mother=HIGGS;}
+      if(HasAnyMother(&(*GenParticles)[i], 1000015) > 0) {info |= 1<<4;mother=STAU;}
 	    fill = true;
 	  }
 

--- a/Producer/plugins/NTupleMaker.h
+++ b/Producer/plugins/NTupleMaker.h
@@ -1036,6 +1036,10 @@ class NTupleMaker : public edm::EDAnalyzer{
   Float_t gentau_e[M_taumaxcount];
   Float_t gentau_charge[M_taumaxcount];
 
+  Float_t gentau_vx[M_taumaxcount];
+  Float_t gentau_vy[M_taumaxcount];
+  Float_t gentau_vz[M_taumaxcount];
+
   Float_t gentau_visible_px[M_taumaxcount];
   Float_t gentau_visible_py[M_taumaxcount];
   Float_t gentau_visible_pz[M_taumaxcount];

--- a/Producer/plugins/NTupleMaker.h
+++ b/Producer/plugins/NTupleMaker.h
@@ -276,7 +276,7 @@ class NTupleMaker : public edm::EDAnalyzer{
 
 
  private:
-  enum MotherNames{HIGGS=1, WBOSON, ZBOSON, TAU};
+  enum MotherNames{HIGGS=1, WBOSON, ZBOSON, TAU, STAU};
   enum MvaMetChannel{EMU=1, ETAU, MUTAU, TAUTAU, MUMU, EE, UNKNOWN};
 
   virtual void beginJob();


### PR DESCRIPTION
1) Added STAU field in the enum MotherNames class. As the MotherName is implicitly converted then to UChar_t (1byte=2^8=256 numbers) there should be no problems with adding a fifth element in this class.
2) Added STAU as mother info, encoded in the _info variable, as 5-th bit as this number is UInt_t there is no limitation either.
3) Added vertex info for the gentau branches